### PR TITLE
Release: v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.13.0]
+## [0.13.0] - 11/09/2023
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0]
+
+### Added
+
+* `pdm add -ce` or `--conda-excludes` add PyPi packages to the excluded from Conda resolution.
+* `pdm add --conda-as-default-manager` sets Conda as default manager.
+
+### Fixed
+
+* Conda channels are correctly saved when added using `pdm add -c` command and Conda configuration was not initialized
+  before.
+* Don't include dev groups when invoking `pdm lock -G :all --prod`.
+* Ensure `cross_platform` is always false when using Conda.
+
 ## [0.12.2] - 10/09/2023
 
 ### Fixed
@@ -46,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* If `conda.as-defualt-manager` is `true` then add requirements to `conda.dependencies` if they aren't python packages
+* If `conda.as-default-manager` is `true` then add requirements to `conda.dependencies` if they aren't python packages
   when using `pdm add` without `--conda` flag.
 
 ## [0.10.0] - 22/05/2023

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The following commands were tested and work:
     * You can specify per package Conda channel using conda notation `channel::package`.
     * You also can specify a default Conda channel with `-c` or `--channel`.
     * With flag `-r` or `--runner` you can specify the Conda runner to use.
+    * With flag `-ce` or `--conda-excludes` you can add PyPi packages to the excluded from Conda resolution.
+    * With flag `--conda-as-default-manager` you can set `conda.as-default-manager` to `True`.
 * `pdm remove`
 * `pdm update`
 * `pdm list`

--- a/src/pdm_conda/__init__.py
+++ b/src/pdm_conda/__init__.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from pdm.core import Core
 
 logger = termui.logger
-__version__ = "0.12.2"
+__version__ = "0.13.0"
 
 
 def main(core: Core):

--- a/src/pdm_conda/cli/commands/lock.py
+++ b/src/pdm_conda/cli/commands/lock.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
         if project.conda_config.is_initialized:
             # conda don't produce cross-platform locks
             options.cross_platform = False
-        if options.groups:
-            if ":all" in options.groups:
-                options.groups += list(project.iter_groups())
+            if options.groups:
+                if ":all" in options.groups:
+                    options.groups += list(project.iter_groups(dev=True if options.dev is None else options.dev))
         super().handle(project=project, options=options)

--- a/src/pdm_conda/models/config.py
+++ b/src/pdm_conda/models/config.py
@@ -84,6 +84,7 @@ _CONFIG_MAP |= {
     "pypi-mapping.url": "mapping_url",
 }
 _CONFIG_MAP |= {v: k for k, v in _CONFIG_MAP.items()}
+_CONFIG_MAP["_excludes"] = "excludes"
 
 CONFIGS = [(f"conda.{name}", config) for name, config in CONFIGS]
 PDM_CONFIG = {
@@ -144,8 +145,8 @@ class PluginConfig:
         super().__setattr__(name, value)
         # if plugin config is set then maybe update pyproject settings
         if (
-            not name.startswith("_")
-            and (not isinstance(getattr(type(self), name, None), property) or name == "excludes")
+            ((not name.startswith("_")) or name == "_excludes")
+            and not isinstance(getattr(type(self), name, None), property)
             and not callable(getattr(self, name))
         ):
             name = f"conda.{_CONFIG_MAP[name]}"

--- a/src/pdm_conda/project/core.py
+++ b/src/pdm_conda/project/core.py
@@ -116,12 +116,15 @@ class CondaProject(Project):
             settings = _getter(settings, f"{name}-dependencies", dict(), set_defaults)
         return _getter(settings, group, [], set_defaults)
 
-    def iter_groups(self) -> Iterable[str]:
+    def iter_groups(self, dev: bool = True) -> Iterable[str]:
         groups = set(super().iter_groups())
         config = self.conda_config
-        for deps in (config.optional_dependencies, config.dev_dependencies):
-            if deps:
+        for is_dev, deps in ((False, config.optional_dependencies), (True, config.dev_dependencies)):
+            if deps and (dev or not is_dev):
                 groups.update(deps.keys())
+        if not dev:
+            for group in self.pyproject.settings.get("dev-dependencies", {}):
+                groups.remove(group)
         return groups
 
     def get_dependencies(self, group: str | None = None) -> dict[str, Requirement]:


### PR DESCRIPTION
This PR includes the following changes:
### Added

* `pdm add -ce` or `--conda-excludes` add PyPi packages to the excluded from Conda resolution.
* `pdm add --conda-as-default-manager` sets Conda as default manager.

### Fixed

* Conda channels are correctly saved when added using `pdm add -c` command and Conda configuration was not initialized
  before.
* Don't include dev groups when invoking `pdm lock -G :all --prod`.
* Ensure `cross_platform` is always false when using Conda.
