### PR TITLE
Release: v0.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.5] - 08/05/2024
+
 ### Changed
 
 * Allow selecting a Conda environment on `pdm use` even if base environment is active.
+* Force Conda to always fetch all packages info con `conda create --dry-run`.
 
 ### Fixed
 

--- a/src/pdm_conda/__init__.py
+++ b/src/pdm_conda/__init__.py
@@ -17,6 +17,7 @@ def main(core: Core):
     from pdm_conda.cli.commands.add import Command as AddCommand
     from pdm_conda.cli.commands.init import Command as InitCommand
     from pdm_conda.cli.commands.install import Command as InstallCommand
+    from pdm_conda.cli.commands.list import Command as ListCommand
     from pdm_conda.cli.commands.lock import Command as LockCommand
     from pdm_conda.cli.commands.remove import Command as RemoveCommand
     from pdm_conda.cli.commands.update import Command as UpdateCommand
@@ -32,13 +33,14 @@ def main(core: Core):
     core.project_class = CondaProject
 
     for cmd in [
-        InitCommand,
         AddCommand,
-        RemoveCommand,
-        UpdateCommand,
-        LockCommand,
+        InitCommand,
         InstallCommand,
+        ListCommand,
+        LockCommand,
+        RemoveCommand,
         VenvCommand,
+        UpdateCommand,
         UseCommand,
     ]:
         core.register_command(cmd)

--- a/src/pdm_conda/__init__.py
+++ b/src/pdm_conda/__init__.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from pdm.core import Core
 
 logger = termui.logger
-__version__ = "0.17.5-dev6"
+__version__ = "0.17.5-dev7"
 
 
 def main(core: Core):

--- a/src/pdm_conda/__init__.py
+++ b/src/pdm_conda/__init__.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from pdm.core import Core
 
 logger = termui.logger
-__version__ = "0.17.5-dev7"
+__version__ = "0.17.5"
 
 
 def main(core: Core):

--- a/src/pdm_conda/cli/commands/list.py
+++ b/src/pdm_conda/cli/commands/list.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pdm.cli.commands.list import Command as BaseCommand
+
+from pdm_conda.cli.utils import ensure_logger
+
+if TYPE_CHECKING:
+    import argparse
+
+    from pdm_conda.project import Project
+
+
+class Command(BaseCommand):
+    description = BaseCommand.__doc__
+    name = "list"
+
+    def handle(self, project: Project, options: argparse.Namespace) -> None:
+        with ensure_logger(project, "use"):
+            super().handle(project, options)

--- a/src/pdm_conda/cli/commands/list.py
+++ b/src/pdm_conda/cli/commands/list.py
@@ -17,5 +17,5 @@ class Command(BaseCommand):
     name = "list"
 
     def handle(self, project: Project, options: argparse.Namespace) -> None:
-        with ensure_logger(project, "use"):
+        with ensure_logger(project, "list"):
             super().handle(project, options)

--- a/src/pdm_conda/cli/commands/venv/utils.py
+++ b/src/pdm_conda/cli/commands/venv/utils.py
@@ -9,7 +9,6 @@ from pdm.cli.commands.venv import list, utils
 from pdm.models.venv import VirtualEnv
 
 from pdm_conda.conda import conda_env_list
-from pdm_conda.environments import CondaEnvironment
 from pdm_conda.utils import get_python_dir
 
 if TYPE_CHECKING:
@@ -22,17 +21,16 @@ get_venv_prefix = utils.get_venv_prefix
 
 
 def find_pythons(project) -> Iterable[PythonVersion]:
-    if isinstance(project.environment, CondaEnvironment):
-        python_suffix = "bin/python" if sys.platform != "win32" else "python.exe"
-        for env in conda_env_list(project):
-            if env != project.environment.base_env and env.parent != project.environment.base_env.parent:
-                python_bin = env / python_suffix
-                if python_bin.exists():
-                    yield CondaProvider.version_maker(
-                        python_bin,
-                        _interpreter=python_bin,
-                        keep_symlink=False,
-                    )
+    python_suffix = "bin/python" if sys.platform != "win32" else "python.exe"
+    for env in conda_env_list(project):
+        if env != project.base_env and env.parent != project.base_env.parent:
+            python_bin = env / python_suffix
+            if python_bin.exists():
+                yield CondaProvider.version_maker(
+                    python_bin,
+                    _interpreter=python_bin,
+                    keep_symlink=False,
+                )
 
 
 class CondaProvider(BaseProvider):

--- a/src/pdm_conda/conda.py
+++ b/src/pdm_conda/conda.py
@@ -7,7 +7,7 @@ import subprocess
 from functools import cache
 from pathlib import Path
 from shutil import which
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
 from pdm.cli.commands.venv.backends import VirtualenvCreateError
@@ -64,7 +64,10 @@ def _optional_temporary_file(environment: dict | list):
     :return: Temporary file or None
     """
     if environment:
-        with NamedTemporaryFile(mode="w+", suffix=".yml" if isinstance(environment, dict) else ".lock") as f:
+        with (
+            TemporaryDirectory() as temp_dir,
+            Path(temp_dir).joinpath("lock" + ".yml" if isinstance(environment, dict) else ".lock").open("w+") as f,
+        ):
             yield f
     else:
         yield

--- a/src/pdm_conda/environments/conda.py
+++ b/src/pdm_conda/environments/conda.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from pdm.models.in_process import get_sys_config_paths
 from pdm.models.specifiers import PySpecSet
 
-from pdm_conda.conda import conda_base_path, conda_create, conda_info, conda_list, conda_search
+from pdm_conda.conda import conda_create, conda_info, conda_list, conda_search
 from pdm_conda.environments.python import PythonEnvironment
 from pdm_conda.models.config import CondaRunner, CondaSolver
 from pdm_conda.project import CondaProject
@@ -49,12 +49,6 @@ class CondaEnvironment(PythonEnvironment):
     def default_channels(self) -> list[str]:
         self._check_update_info(self._default_channels)
         return self._default_channels  # type: ignore
-
-    @property
-    def base_env(self) -> Path:
-        if self._base_env is None:
-            self._base_env = conda_base_path(self.project)
-        return self._base_env
 
     def _check_update_info(self, prop):
         if prop is None:

--- a/src/pdm_conda/models/config.py
+++ b/src/pdm_conda/models/config.py
@@ -16,7 +16,7 @@ from pdm.utils import normalize_name
 from pdm_conda import logger
 from pdm_conda.mapping import MAPPING_DOWNLOAD_DIR_ENV_VAR, MAPPING_URL, MAPPING_URL_ENV_VAR
 from pdm_conda.models.requirements import parse_requirement
-from pdm_conda.utils import fix_path
+from pdm_conda.utils import fix_path, get_python_dir
 
 if TYPE_CHECKING:
     from typing import Any
@@ -382,8 +382,5 @@ class PluginConfig:
         ):
             _command += ["--solver", CondaSolver.MAMBA.value]
         if use_project_env and cmd.split(" ")[0] not in ("search", "env", "info"):
-            _command += [
-                "--prefix",
-                str(fix_path(self._project.environment.interpreter.path)).replace("/bin/python", ""),
-            ]
+            _command += ["--prefix", str(get_python_dir(fix_path(self._project.environment.interpreter.path)))]
         return _command

--- a/src/pdm_conda/models/config.py
+++ b/src/pdm_conda/models/config.py
@@ -375,7 +375,11 @@ class PluginConfig:
             _command.append("-y")
         if cmd in ("install", "create") or (cmd == "search" and self.runner == CondaRunner.MICROMAMBA):
             _command.append("--strict-channel-priority")
-        if self.runner == CondaRunner.CONDA and self.solver == CondaSolver.MAMBA and cmd in ("create", "install"):
+        if (
+            self.runner in (CondaRunner.CONDA, CondaRunner.MAMBA)
+            and self.solver == CondaSolver.MAMBA
+            and cmd in ("create", "install")
+        ):
             _command += ["--solver", CondaSolver.MAMBA.value]
         if use_project_env and cmd.split(" ")[0] not in ("search", "env", "info"):
             _command += [

--- a/src/pdm_conda/project/core.py
+++ b/src/pdm_conda/project/core.py
@@ -10,6 +10,7 @@ from pdm.project.lockfile import Lockfile
 from pdm.utils import get_venv_like_prefix
 from tomlkit.items import Array
 
+from pdm_conda import logger
 from pdm_conda.models.config import PluginConfig
 from pdm_conda.models.requirements import CondaRequirement, as_conda_requirement, is_conda_managed, parse_requirement
 from pdm_conda.project.project_file import PyProject
@@ -209,12 +210,11 @@ class CondaProject(Project):
     def get_environment(self) -> BaseEnvironment:
         if not self.conda_config.is_initialized:
             return super().get_environment()
-
+        if not get_venv_like_prefix(self.python.executable)[1]:
+            logger.debug("Conda environment not detected.")
+            return super().get_environment()
         if not self.config["python.use_venv"]:
             raise ProjectError("python.use_venv is required to use Conda.")
-        if not get_venv_like_prefix(self.python.executable)[1]:
-            raise ProjectError("Conda environment not detected.")
-
         return self.environment_class(self)
 
     def get_provider(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,13 +218,13 @@ def mock_conda(
                     channel_url(f"{DEFAULT_CHANNEL}/noarch"),
                 ],
             }
-
+            base_env = "/opt/conda/base"
             if runner != "micromamba":
                 info["virtual_pkgs"] = virtual_packages
-                info["base environment"] = CONDA_PREFIX
+                info["base environment"] = base_env
             else:
                 info["virtual packages"] = ["=".join(p) for p in virtual_packages]
-                info["root_prefix"] = CONDA_PREFIX
+                info["root_prefix"] = base_env
 
             return info
         if subcommand in ("repoquery", "search"):

--- a/tests/data/pyproject_1.toml
+++ b/tests/data/pyproject_1.toml
@@ -27,7 +27,7 @@ prefect-worker = [
 ]
 
 [tool.pdm.conda]
-runner = "micromamba"
+runner = "mamba"
 solver = "libmamba"
 channels = ["conda-forge"]
 custom-behavior = true
@@ -40,6 +40,9 @@ excludes = [
 
 [tool.pdm]
 distribution = false
+plugins = [
+    "-e pdm_conda @ file:///C:/Users/Student/pdm-conda"
+]
 
 [tool.pdm.resolution.overrides]
 trio = "<0.22"

--- a/tests/data/pyproject_1.toml
+++ b/tests/data/pyproject_1.toml
@@ -27,8 +27,7 @@ prefect-worker = [
 ]
 
 [tool.pdm.conda]
-runner = "mamba"
-solver = "libmamba"
+runner = "micromamba"
 channels = ["conda-forge"]
 custom-behavior = true
 as-default-manager = true
@@ -40,9 +39,6 @@ excludes = [
 
 [tool.pdm]
 distribution = false
-plugins = [
-    "-e pdm_conda @ file:///C:/Users/Student/pdm-conda"
-]
 
 [tool.pdm.resolution.overrides]
 trio = "<0.22"

--- a/tests/test_add_remove.py
+++ b/tests/test_add_remove.py
@@ -132,13 +132,7 @@ class TestAddRemove:
         cmd_order = []
         if packages_to_remove:
             # get working set + get python packages
-            cmd_order = ["list", "list"]
-            if project.conda_config.runner in ("mamba", "micromamba") or project.conda_config.solver == "libmamba":
-                cmd_order.append("create")
-            else:
-                num_searches = len(python_packages)
-                cmd_order += ["search" if runner == "conda" else "repoquery"] * num_searches
-            cmd_order += ["remove"] * (1 if batch_commands else len(packages_to_remove))
+            cmd_order = ["list", "list", "create"] + ["remove"] * (1 if batch_commands else len(packages_to_remove))
         assert conda.call_count == len(cmd_order)
 
         dependencies = project.get_dependencies(group)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -33,7 +33,7 @@ def prepare_env(project, runner):
         if runner == "conda":
             pass
         subprocess.run(
-            ["micromamba", "install", "-y", runner, "-c", "conda-forge"],
+            ["micromamba", "install", "-y", runner, "-c", "conda-forge", "-n", "base"],
             check=True,
             capture_output=True,
         )

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -80,7 +80,7 @@ class TestVenv:
 
         pdm(cmd, obj=project, strict=True)
 
-        cmd_order = ["create"]
+        cmd_order = ["info", "create"]
         if conda_name and not venv_location:
             cmd_order = ["env"] + cmd_order
         venv_name = conda_name if conda_name else f"{project.root.name}-"
@@ -98,7 +98,7 @@ class TestVenv:
                 else:
                     assert env_prefix.parent == conda_envs_path
                     assert conda_envs_path != project.config["venv.location"]
-            else:
+            elif conda_venv_command != "info":
                 assert (prefix_index := cmd.index("--prefix")) != -1
                 assert venv_name in cmd[prefix_index + 1]
 
@@ -145,7 +145,7 @@ class TestVenv:
                 assert f"{project.root.name}-" in result.output
 
         assert "Virtualenv is created successfully" not in result.output
-        conda_calls = ["info", "env list"]
+        conda_calls = ["env list", "info"]
         assert conda.call_count == len(conda_calls)
         for ((cmd,), _), expected_cmd in zip(conda.call_args_list, conda_calls, strict=False):
             assert " ".join(cmd).startswith(f"{runner} {expected_cmd}")


### PR DESCRIPTION
This PR includes:
### Changed

* Allow selecting a Conda environment on `pdm use` even if base environment is active.
* Force Conda to always fetch all packages info con `conda create --dry-run`.

### Fixed

* Don't show duplicated Conda interpreters on `pdm use`.
* Don't show base Conda env on `pdm env list` or `pdm use`.
* Write plugin related changes on `pdm venv create --with`.
* Fix paths when using on Windows.
* Fix Conda environments not showing on Windows.