### PR TITLE
Fix: Avoid concurrent Conda calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Avoid making Conda concurrent executions when using `pdm add/remove/update/install/sync` commands.
+
+
 ## [0.18.1] - 08/06/2024
 
 ### Fixed

--- a/deploy/docker-compose.dev.yaml
+++ b/deploy/docker-compose.dev.yaml
@@ -10,6 +10,7 @@ services:
         local_path: $PWD
     image: pdm-conda:latest-dev
     platform: linux/x86_64
+    restart: no
     volumes:
       - ../tests:/app/tests
       - ../src/pdm_conda:/app/src/pdm_conda

--- a/src/pdm_conda/cli/commands/update.py
+++ b/src/pdm_conda/cli/commands/update.py
@@ -67,3 +67,5 @@ class Command(BaseCommand):
                     write=(write := i == num_groups - 1),
                     show_message=write,
                 )
+
+            project.lockfile.write(show_message=False)


### PR DESCRIPTION
This PR includes:
### Changed

* Avoid making Conda concurrent executions when using `pdm add/remove/update/install/sync` commands.
